### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HexoMD
 
 给自己用的markdown编辑器
 
-###下载
+### 下载
 这是打包好的链接,有自动更新功能,下载后请先更新到最新版  
 [绿色版win64 v1.0.0.0](http://pan.baidu.com/s/1eQEw1Wm)  
 [绿色版win32 v1.2.0.0](http://pan.baidu.com/s/1nubrefn)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
